### PR TITLE
caches the memers list (/members) as well as User::publicEventCount

### DIFF
--- a/app/Console/Commands/BuildCache.php
+++ b/app/Console/Commands/BuildCache.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Member;
+use App\Http\Controllers\MemberController;
+class BuildCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:build';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Builds up the cache';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        foreach (Member::all() as $member) {
+            $member->buildPublicEventCountCache();
+        }
+        $this->info('Member public event cache built.');
+        MemberController::buildMembersListCache();
+        $this->info('Member list cache built.');
+
+
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         Commands\Inspire::class,
+        Commands\BuildCache::class,
     ];
 
     /**
@@ -24,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('inspire')
-                 ->hourly();
+        $schedule->command('inspire')->hourly();
+        $schedule->command('cache:build')->hourly();
     }
 }

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -24,15 +24,16 @@ class MemberController extends BaseController {
 	/////////////////////////////// Viewing Members ///////////////////////////////
 	
 	public function getIndex(Request $request) {
-		$minutesToCache = 60;
-		
-		$members = Cache::remember('members_list', $minutesToCache, function () {
+		$members = Cache::get('members_list', self::buildMembersListCache());
+		return view('pages.members',compact("members"));
+	}
+
+	public static function buildMembersListCache() {
+		return Cache::remember('members_list', 65, function () {
 			return Member::with('events')->get()->sortBy(function($member, $key) {
 				return sprintf('%04d',1000-$member->publicEventCount())."_".$member->name;
 			});
 		});
-		
-		return view('pages.members',compact("members"));
 	}
 	
 	public function getMember(Request $request, $memberID) {

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -7,7 +7,7 @@
 */
 
 namespace App\Models;
-
+use Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
@@ -37,7 +37,7 @@ class Member extends Authenticatable {
 	}
 	
 	public function publicEventCount() {
-		return $this->events()->where('privateEvent',false)->count();
+		return Cache::get('member_public_events_'.$this->id,$this->buildPublicEventCountCache());
 	}
 	
 	public function applications() {
@@ -68,6 +68,11 @@ class Member extends Authenticatable {
 	public function resumePath() {
 		$fileExt = pathinfo($this->resume, PATHINFO_EXTENSION);
 		return '/uploads/resumes/'.$this->id."_".substr(md5($this->resume), -6).'.'.$fileExt;
+	}
+	public function buildPublicEventCountCache() {
+		return Cache::remember('member_public_events_'.$this->id, 65, function () {
+		    return $this->events()->where('privateEvent',false)->count();
+		});
 	}
 	
 }


### PR DESCRIPTION
Cache is updated hourly, and has expiry of 65 minutes just in case something is slow 🤔

requires `* * * * * php /path/to/artisan schedule:run >> /dev/null 2>&1` in the crontab for production (see [the docs](https://laravel.com/docs/5.2/scheduling)).

For development testing, you can just run `php artisan cache:build` (what the crontab calls)

If caches for some reason aren't built by the cron job, they will fall back to being generated on the fly (at the expense of the user)